### PR TITLE
Add github repo link to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -47,7 +47,7 @@ export default function Footer() {
           <div>
             <h4 className="font-semibold mb-4">Resources</h4>
             <ul className="space-y-2 text-gray-400">
-              <li><Link href="#" className="hover:text-white transition-colors">Scholarships</Link></li>
+              <li><Link href="https://github.com/adriancancode/shpe-csuf" target="_blank" className="hover:text-white transition-colors">Source Code</Link></li>
               <li><Link href="#" className="hover:text-white transition-colors">Career Center</Link></li>
               <li><Link href="#" className="hover:text-white transition-colors">Mentorship</Link></li>
               <li><Link href="#" className="hover:text-white transition-colors">Newsletter</Link></li>


### PR DESCRIPTION
![shpe-footer](https://github.com/user-attachments/assets/cd80e711-dd5a-4546-8c14-2317d4589787)

I added a link to the source code and github repo for this website on the footer underneath "Resources" so that anyone who wants to check out the code of this site can gladly do so by clicking on it.